### PR TITLE
Fix RedHat and Debian OS version checks on systemd

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -199,15 +199,15 @@ define redis::server (
   case $::operatingsystem {
     'Fedora', 'RedHat', 'CentOS', 'OEL', 'OracleLinux', 'Amazon', 'Scientific': {
       $service_file = "/usr/lib/systemd/system/redis-server_${redis_name}.service"
-      if versioncmp($::operatingsystemmajrelease, '7') > 0 { $has_systemd = true }
+      if versioncmp($::operatingsystemmajrelease, '7') >= 0 { $has_systemd = true }
     }
     'Debian': {
       $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
-      if versioncmp($::operatingsystemmajrelease, '8') > 0 { $has_systemd = true }
+      if versioncmp($::operatingsystemmajrelease, '8') >= 0 { $has_systemd = true }
     }
     'Ubuntu': {
       $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
-      if versioncmp($::operatingsystemmajrelease, '14.04') > 0 { $has_systemd = true }
+      if versioncmp($::operatingsystemmajrelease, '15.04') >= 0 { $has_systemd = true }
     }
     default:  {
       $service_file = "/etc/init.d/redis-server_${redis_name}"


### PR DESCRIPTION
RedHat family and Debian were not properly comparing the output for versioncmp, also updated the Ubuntu case to match the others. 

Systemd available in:
RedHat family: 7+
Debian: 8+
Ubuntu 15.04+