### PR TITLE
Enable disabling bgsave again if array is default (empty)

### DIFF
--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -96,9 +96,13 @@ databases <%= @redis_nr_dbs %>
 #
 #   Note: you can disable saving at all commenting all the "save" lines.
 
+<% if !@save.empty? -%>
 <% @save.each do |seconds, changes| %>
   save <%= seconds %> <%= changes %>
 <% end %>
+<% else -%>
+  save ""
+<% end -%>
 
 # Compress string objects using LZF when dump .rdb databases?
 # For default that's set to 'yes' as it's almost always a win.


### PR DESCRIPTION
Changed in Redis 6.2
https://raw.githubusercontent.com/antirez/redis/6.2/00-RELEASENOTES
* Not resetting "save" config when Redis is started with command line arguments. (#7092)
  In case you provide command line arguments without "save" and count on it
  being disabled, Now the defaults "save" config will kick in.